### PR TITLE
Add term 'identity' to names.json

### DIFF
--- a/names.json
+++ b/names.json
@@ -420,6 +420,7 @@
     "icon",
     "icons",
     "id",
+    "identity",
     "idp",
     "ielp",
     "iheartmedia",


### PR DESCRIPTION
This PR adds the term `identity` as it is widely used as a subdomain for profile management, login and registration.